### PR TITLE
fix: correct swapped 255UInt16 control codes in WOFF2 encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "ttf2woff2"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "brotli",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttf2woff2"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "A Pure Rust library and CLI for compressing TTF fonts to WOFF2 format."
 authors = ["kaoru <k@warpnine.io>"]

--- a/src/woff2/varint.rs
+++ b/src/woff2/varint.rs
@@ -39,9 +39,9 @@ pub(super) fn encode_base128(mut value: u32) -> EncodedInt {
 /// 255UInt16 encoding per WOFF2 spec.
 #[inline]
 pub(super) fn encode_255_u_int16(value: u16) -> EncodedInt {
-    const ONE_MORE_BYTE_CODE1: u8 = 253;
+    const WORD_CODE: u8 = 253;
     const ONE_MORE_BYTE_CODE2: u8 = 254;
-    const WORD_CODE: u8 = 255;
+    const ONE_MORE_BYTE_CODE1: u8 = 255;
 
     if value < 253 {
         InlineBytes::new([value as u8, 0, 0, 0, 0], 1)
@@ -71,11 +71,11 @@ mod tests {
     fn test_encode_255_u_int16() {
         assert_eq!(encode_255_u_int16(0).as_slice(), &[0]);
         assert_eq!(encode_255_u_int16(252).as_slice(), &[252]);
-        assert_eq!(encode_255_u_int16(253).as_slice(), &[253, 0]);
-        assert_eq!(encode_255_u_int16(505).as_slice(), &[253, 252]);
+        assert_eq!(encode_255_u_int16(253).as_slice(), &[255, 0]);
+        assert_eq!(encode_255_u_int16(505).as_slice(), &[255, 252]);
         assert_eq!(encode_255_u_int16(506).as_slice(), &[254, 0]);
         assert_eq!(encode_255_u_int16(761).as_slice(), &[254, 255]);
-        assert_eq!(encode_255_u_int16(762).as_slice(), &[255, 0x02, 0xFA]);
-        assert_eq!(encode_255_u_int16(0xFFFF).as_slice(), &[255, 0xFF, 0xFF]);
+        assert_eq!(encode_255_u_int16(762).as_slice(), &[253, 0x02, 0xFA]);
+        assert_eq!(encode_255_u_int16(0xFFFF).as_slice(), &[253, 0xFF, 0xFF]);
     }
 }


### PR DESCRIPTION
Issue:

encode_255_u_int16 had the WORD_CODE and ONE_MORE_BYTE_CODE1 constants swapped: it used 253 as the one-more-byte prefix and 255 as the word prefix. The WOFF2 spec defines 253 as the word code (followed by a 2-byte big-endian u16) and 255 as oneMoreByteCode1 (value = next byte + 253). A value such as 398 was emitted as [253, 145]; a spec-compliant decoder reads the 253 as the word code and consumes [145, <next byte>] as a u16, producing a wrong length that desyncs the glyf stream and corrupts the reconstructed font.

Dependence on font size / glyph count:

255UInt16 only uses a multi-byte form for values >= 253. The encoder applies it to per-contour point counts and per-glyph instruction lengths in the glyf transform. Small or simple fonts keep every such value under 253, so only the correct single-byte path is taken and the output is valid. The bug is triggered only once a glyph has a contour with >= 253 points or >= 253 bytes of instructions, which appears in larger / more complex fonts (e.g. CJK). This is why small fonts encoded correctly while large fonts produced output that decoders rejected.

Solution:

Swap the constants so WORD_CODE = 253 and ONE_MORE_BYTE_CODE1 = 255, matching the spec. Updated the encode_255_u_int16 unit test to the spec-correct expected bytes (the previous expectations encoded the bug). Verified by full per-glyph round-trip (coordinates, contour endpoints, on-curve flags, instruction bytecode) of a 61360-glyph font: 0 mismatches, and the reference woff2 decoder accepts the output.
